### PR TITLE
VZ-9237 crio validation

### DIFF
--- a/controlplane/ocne/api/v1alpha1/ocne_control_plane_webhook.go
+++ b/controlplane/ocne/api/v1alpha1/ocne_control_plane_webhook.go
@@ -714,7 +714,7 @@ func (in *OCNEControlPlane) validateOCNEData(inClusterConfiguration *bootstrapv1
 
 func (in *OCNEControlPlane) validateOCNESocket(controlPlaneConfigSpec *bootstrapv1.OCNEConfigSpec) (allErrs field.ErrorList) {
 
-	if controlPlaneConfigSpec == nil {
+	if controlPlaneConfigSpec == nil || controlPlaneConfigSpec.InitConfiguration == nil || controlPlaneConfigSpec.JoinConfiguration == nil {
 		return allErrs
 	}
 

--- a/controlplane/ocne/api/v1alpha1/ocne_control_plane_webhook.go
+++ b/controlplane/ocne/api/v1alpha1/ocne_control_plane_webhook.go
@@ -105,6 +105,7 @@ func (in *OCNEControlPlane) ValidateCreate() error {
 	allErrs := validateKubeadmControlPlaneSpec(spec, in.Namespace, field.NewPath("spec"))
 	allErrs = append(allErrs, validateClusterConfiguration(spec.ControlPlaneConfig.ClusterConfiguration, nil, field.NewPath("spec", "controlPlaneConfig", "clusterConfiguration"))...)
 	allErrs = append(allErrs, in.validateOCNEData(in.Spec.ControlPlaneConfig.ClusterConfiguration, in.Spec.Version)...)
+	allErrs = append(allErrs, in.validateOCNESocket(&in.Spec.ControlPlaneConfig)...)
 	allErrs = append(allErrs, spec.ControlPlaneConfig.Validate(field.NewPath("spec", "controlPlaneConfig"))...)
 	if len(allErrs) > 0 {
 		return apierrors.NewInvalid(GroupVersion.WithKind("OCNEControlPlane").GroupKind(), in.Name, allErrs)


### PR DESCRIPTION
This change will prevent using containerd to be used as a crisocket 

```
The OCNEControlPlane "ocne-control-plane" is invalid:
* initConfiguration.nodeRegistration.criSocket: Invalid value: "/var/run/containerd/containerd.sock": only '/var/run/crio/crio.sock' is supported as criSocket with OCNE
* joinConfiguration.nodeRegistration.criSocket: Invalid value: "/var/run/containerd/containerd.sock": only '/var/run/crio/crio.sock' is supported as criSocket with OCNE
```