### PR TITLE
JIRA: VZ-9710 fix cluster role generation for standalone deployment

### DIFF
--- a/controlplane/ocne/config/rbac/role.yaml
+++ b/controlplane/ocne/config/rbac/role.yaml
@@ -52,6 +52,17 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create
@@ -63,7 +74,6 @@ rules:
   - ""
   resources:
   - secrets
-  - configmaps
   verbs:
   - create
   - get

--- a/controlplane/ocne/internal/controllers/controller.go
+++ b/controlplane/ocne/internal/controllers/controller.go
@@ -59,6 +59,7 @@ import (
 
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io;bootstrap.cluster.x-k8s.io;controlplane.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
Kubebuilder annotation was required to be added to facilitate dynamic creation of cluster role entry for configmaps.