### PR TITLE
VZ-9701 new find syntax to avoid errors in linux envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,7 @@ docker-pull-prerequisites:
 generate-modules-repo-artifacts:
 	git clone https://github.com/verrazzano/verrazzano-modules.git
 	cd $(ROOT_DIR)/verrazzano-modules/module-operator/manifests/charts/modules; \
- 	find . -type d -depth 1 -exec helm package -u '{}' \; && helm repo index . ; \
+ 	find . -type d -exec helm package -u '{}' \; && helm repo index . ; \
  	mv $(ROOT_DIR)/verrazzano-modules/module-operator/manifests/charts/modules/index.yaml $(ROOT_DIR); \
  	cp -R $(ROOT_DIR)/verrazzano-modules/module-operator/manifests/charts $(ROOT_DIR); \
  	rm -rf $(ROOT_DIR)/charts/modules/*.tgz


### PR DESCRIPTION
Removing the 'depth' option simplifies the command and executes successfully on both linux and mac platforms.  There are some additional 'missing Chart.yaml' messages printed out during index.yaml generation but they do not affect processing.