### PR TITLE
VZ-9701 add POD_NAMESPACE env var to bootstrap controller deployment

### DIFF
--- a/bootstrap/ocne/config/manager/manager.yaml
+++ b/bootstrap/ocne/config/manager/manager.yaml
@@ -23,6 +23,11 @@ spec:
         - "--metrics-bind-addr=localhost:8080"
         - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false}"
         - "--bootstrap-token-ttl=${KUBEADM_BOOTSTRAP_TOKEN_TTL:=15m}"
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: controller:latest
         name: manager
         ports:


### PR DESCRIPTION
Add the env var to allow the successful lookup of co-located metadata resource