### PR TITLE
Fixes for VPO helm chart install

### DIFF
--- a/controlplane/ocne/config/default/manager_image_patch.yaml
+++ b/controlplane/ocne/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
   template:
     spec:
       containers:
-        - image: iad.ocir.io/odsbuilddev/sandboxes/verrazzano/cluster-api-ocne-control-plane-controller:v0.1.0-912e7a5
+        - image: ghcr.io/verrazzano/cluster-api-ocne-control-plane-controller
           name: manager

--- a/controlplane/ocne/config/default/manager_image_patch.yaml
+++ b/controlplane/ocne/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
   template:
     spec:
       containers:
-        - image: ghcr.io/verrazzano/cluster-api-ocne-control-plane-controller
+        - image: iad.ocir.io/odsbuilddev/sandboxes/verrazzano/cluster-api-ocne-control-plane-controller:v0.1.0-912e7a5
           name: manager

--- a/controlplane/ocne/internal/helm/helper.go
+++ b/controlplane/ocne/internal/helm/helper.go
@@ -186,16 +186,10 @@ func parseDefaultVPOImage(vpoImage string) (registry string, repo string, image 
 	tag = splitTag[1]
 	splitImage := strings.Split(splitTag[0], "/")
 	image = splitImage[len(splitImage)-1]
-	regRepo := strings.ReplaceAll(splitTag[0], "/"+image, "")
+	regRepo := strings.TrimSuffix(splitTag[0], "/"+image)
 	splitRegistry := strings.Split(regRepo, "/")
 	registry = splitRegistry[0]
-	repo = strings.ReplaceAll(regRepo, registry+"/", "")
-	splitRepo := strings.Split(repo, "/")
-	if len(splitRepo) == 1 {
-		repo = ""
-	} else {
-		repo = strings.ReplaceAll(repo, "/"+"verrazzano", "")
-	}
+	repo = strings.TrimPrefix(regRepo, registry+"/")
 	return registry, repo, image, tag
 }
 
@@ -222,11 +216,7 @@ func generateDataValuesForVerrazzanoPlatformOperator(ctx context.Context, spec *
 	if spec.Image != nil {
 		// Set defaults or honor overrides
 		if spec.Image.Repository == "" {
-			if repo != "" {
-				helmMeta.Image = fmt.Sprintf("%s/%s/%s", registry, repo, image)
-			} else {
-				helmMeta.Image = fmt.Sprintf("%s/%s", registry, image)
-			}
+			helmMeta.Image = fmt.Sprintf("%s/%s/%s", registry, repo, image)
 		} else {
 			imageList := strings.Split(strings.Trim(strings.TrimSpace(spec.Image.Repository), "/"), "/")
 			if imageList[len(imageList)-1] == image {
@@ -261,7 +251,7 @@ func generateDataValuesForVerrazzanoPlatformOperator(ctx context.Context, spec *
 	if spec.PrivateRegistry.Enabled {
 		helmMeta.PrivateRegistry = true
 		helmMeta.Registry = registry
-		helmMeta.Repository = repo
+		helmMeta.Repository = strings.TrimSuffix(repo, "/verrazzano")
 	}
 
 	// This handles the use case where a developer has built a verrazzano-platform-operator in the non-default

--- a/controlplane/ocne/internal/helm/helper.go
+++ b/controlplane/ocne/internal/helm/helper.go
@@ -75,7 +75,7 @@ type VPOHelmValuesTemplate struct {
 	PullPolicy           string                      `json:"pullPolicy,omitempty"`
 	ImagePullSecrets     []controlplanev1.SecretName `json:"imagePullSecrets,omitempty"`
 	AppOperatorImage     string                      `json:"appOperatorImage,omitempty"`
-	ClusterOperatorImage string                      `json:"ClusterOperatorImage,omitempty"`
+	ClusterOperatorImage string                      `json:"clusterOperatorImage,omitempty"`
 }
 
 func GetCoreV1Client() (v1.CoreV1Interface, error) {

--- a/controlplane/ocne/internal/helm/helper.go
+++ b/controlplane/ocne/internal/helm/helper.go
@@ -194,7 +194,7 @@ func parseDefaultVPOImage(vpoImage string) (registry string, repo string, image 
 	if len(splitRepo) == 1 {
 		repo = ""
 	} else {
-		repo = strings.ReplaceAll(repo, "/"+splitRepo[len(splitRepo)-1], "")
+		repo = strings.ReplaceAll(repo, "/"+"verrazzano", "")
 	}
 	return registry, repo, image, tag
 }

--- a/controlplane/ocne/internal/helm/helper.go
+++ b/controlplane/ocne/internal/helm/helper.go
@@ -190,6 +190,12 @@ func parseDefaultVPOImage(vpoImage string) (registry string, repo string, image 
 	splitRegistry := strings.Split(regRepo, "/")
 	registry = splitRegistry[0]
 	repo = strings.ReplaceAll(regRepo, registry+"/", "")
+	splitRepo := strings.Split(repo, "/")
+	if len(splitRepo) == 1 {
+		repo = ""
+	} else {
+		repo = strings.ReplaceAll(repo, "/"+splitRepo[len(splitRepo)-1], "")
+	}
 	return registry, repo, image, tag
 }
 
@@ -216,7 +222,11 @@ func generateDataValuesForVerrazzanoPlatformOperator(ctx context.Context, spec *
 	if spec.Image != nil {
 		// Set defaults or honor overrides
 		if spec.Image.Repository == "" {
-			helmMeta.Image = fmt.Sprintf("%s/%s/%s", registry, repo, image)
+			if repo != "" {
+				helmMeta.Image = fmt.Sprintf("%s/%s/%s", registry, repo, image)
+			} else {
+				helmMeta.Image = fmt.Sprintf("%s/%s", registry, image)
+			}
 		} else {
 			imageList := strings.Split(strings.Trim(strings.TrimSpace(spec.Image.Repository), "/"), "/")
 			if imageList[len(imageList)-1] == image {

--- a/controlplane/ocne/internal/helm/vpoImageMeta.tmpl
+++ b/controlplane/ocne/internal/helm/vpoImageMeta.tmpl
@@ -3,11 +3,17 @@ createNamespace: false
 image: {{.Image}}
 {{- end }}
 imagePullPolicy: {{.PullPolicy}}
-{{- if or .PrivateRegistry .ImagePullSecrets }}
+{{- if or .PrivateRegistry .ImagePullSecrets .AppOperatorImage .ClusterOperatorImage}}
 global:
 {{- if .PrivateRegistry }}
   registry: {{.Registry}}
   repository: {{.Repository}}
+{{- end }}
+{{- if .AppOperatorImage }}
+  appOperatorImage: {{.AppOperatorImage}}
+{{- end }}
+{{- if .ClusterOperatorImage }}
+  clusterOperatorImage: {{.ClusterOperatorImage}}
 {{- end }}
 {{- if .ImagePullSecrets }}
   imagePullSecrets:


### PR DESCRIPTION
This pull request fixes a couple of bugs related to installing the VPO helm chart.

1. VAO and VCO helm values needed to be set for developer built images.  Without these settings the VAO and VCO images could not be pulled.
2. Fixed a private registry bug where the repository helm value was not set correctly.