### PR TITLE
VZ-10227 ocne upgrade to 1.7 

### DIFF
--- a/bootstrap/ocne/config/default/manager_pull_policy.yaml
+++ b/bootstrap/ocne/config/default/manager_pull_policy.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
       - name: manager
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent

--- a/controlplane/ocne/config/default/manager_pull_policy.yaml
+++ b/controlplane/ocne/config/default/manager_pull_policy.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
       - name: manager
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent

--- a/internal/util/ocne/ocne.go
+++ b/internal/util/ocne/ocne.go
@@ -184,7 +184,7 @@ func GetOCNEOverrides(userData *OCNEOverrideData) ([]string, error) {
 
 	ocneDependenciesInstall := []string{
 		`sudo dnf install -y oracle-olcne-release-el8`,
-		`sudo dnf config-manager --enable ol8_olcne16 ol8_olcne15 ol8_addons ol8_baseos_latest ol8_appstream ol8_UEKR6`,
+		`sudo dnf config-manager --enable ol8_olcne17 ol8_olcne16 ol8_olcne15 ol8_addons ol8_baseos_latest ol8_appstream ol8_UEKR6`,
 		`sudo dnf config-manager --disable ol8_olcne14 ol8_olcne13 ol8_olcne12 ol8_developer`,
 		fmt.Sprintf("sudo dnf install -y kubelet-%s.el8 kubeadm-%s.el8 kubectl-%s.el8 helm-%s.el8", ocneMeta[userData.KubernetesVersion].OCNEPackages.Kubelet, ocneMeta[userData.KubernetesVersion].OCNEPackages.Kubeadm, ocneMeta[userData.KubernetesVersion].OCNEPackages.Kubectl, ocneMeta[userData.KubernetesVersion].OCNEPackages.Helm),
 		`sudo dnf install -y oraclelinux-developer-release-el8 python36-oci-cli olcnectl olcne-api-server olcne-utils`,

--- a/kubernetes-versions.yaml
+++ b/kubernetes-versions.yaml
@@ -315,3 +315,36 @@
     kubectl: 1.25.7-1
     kubelet: 1.25.7-1
     helm: 3.11.1-1
+1.25.11:
+  container-images:
+    pause: 3.8
+    etcd: 3.5.6
+    coredns: v1.9.3
+    kube-controller-manager: v1.25.11
+    kube-scheduler: v1.25.11
+    kube-apiserver: v1.25.11
+    kube-proxy: v1.25.11
+  packages:
+    kubeadm: 1.25.11-1
+    kubectl: 1.25.11-1
+    kubelet: 1.25.11-1
+    helm: 3.11.1-1
+  extra-images:
+    kubernetes-dashboard: v2.5.1
+    flannel: v0.14.1
+    nginx: 1.17.7
+    externalip-webhook: v1.0.0-1
+  1.26.6:
+    container-images:
+      pause: 3.9
+      etcd: 3.5.6
+      coredns: v1.9.3
+      kube-controller-manager: v1.26.6
+      kube-scheduler: v1.26.6
+      kube-apiserver: v1.26.6
+      kube-proxy: v1.26.6
+    packages:
+      kubeadm: 1.26.6-1
+      kubectl: 1.26.6-1
+      kubelet: 1.26.6-1
+      helm: 3.12.0-1

--- a/kubernetes-versions.yaml
+++ b/kubernetes-versions.yaml
@@ -334,17 +334,23 @@
     flannel: v0.14.1
     nginx: 1.17.7
     externalip-webhook: v1.0.0-1
-  1.26.6:
-    container-images:
-      pause: 3.9
-      etcd: 3.5.6
-      coredns: v1.9.3
-      kube-controller-manager: v1.26.6
-      kube-scheduler: v1.26.6
-      kube-apiserver: v1.26.6
-      kube-proxy: v1.26.6
-    packages:
-      kubeadm: 1.26.6-1
-      kubectl: 1.26.6-1
-      kubelet: 1.26.6-1
-      helm: 3.12.0-1
+1.26.6:
+  container-images:
+    pause: 3.9
+    etcd: 3.5.6
+    coredns: v1.9.3
+    kube-controller-manager: v1.26.6
+    kube-scheduler: v1.26.6
+    kube-apiserver: v1.26.6
+    kube-proxy: v1.26.6
+  packages:
+    kubeadm: 1.26.6-1
+    kubectl: 1.26.6-1
+    kubelet: 1.26.6-1
+    helm: 3.12.0-1
+  extra-images:
+    kubernetes-dashboard: v2.5.1
+    flannel: v0.14.1
+    nginx: 1.17.7
+    externalip-webhook: v1.0.0-1
+    module-operator: v1.7.0

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,3 +12,6 @@ releaseSeries:
   - major: 1
     minor: 6
     contract: v1beta1
+  - major: 1
+    minor: 7
+    contract: v1beta1

--- a/util/ocne/versions.go
+++ b/util/ocne/versions.go
@@ -52,6 +52,8 @@ const (
 )
 
 var k8s_ocne_version_maping = map[string]string{
+	"v1.26.6":  "1.7",
+	"v1.25.11": "1.6",
 	"v1.25.7":  "1.6",
 	"v1.24.8":  "1.5",
 	"v1.24.5":  "1.5",


### PR DESCRIPTION
Update K8s versions and yum repo for OCNE 1.7

```
$ k --kubeconfig ocnesg get nodes -o wide
NAME                                           STATUS   ROLES           AGE     VERSION         INTERNAL-IP      EXTERNAL-IP   OS-IMAGE                  KERNEL-VERSION                     CONTAINER-RUNTIME
ocnecapikluster-509ff004-control-plane-kt6zx   Ready    control-plane   18m     v1.26.6+1.el8   100.101.68.184   <none>        Oracle Linux Server 8.8   5.15.0-102.110.5.1.el8uek.x86_64   cri-o://1.26.3
ocnecapikluster-509ff004-md-0-h7mg8            Ready    <none>          7m31s   v1.26.6+1.el8   100.101.68.225   <none>        Oracle Linux Server 8.8   5.15.0-102.110.5.1.el8uek.x86_64   cri-o://1.26.3

$ k --kubeconfig ocnesg get pod -A
NAMESPACE                    NAME                                                                   READY   STATUS    RESTARTS   AGE
calico-apiserver             calico-apiserver-8b9d8f8c6-glhxc                                       1/1     Running   0          13m
calico-apiserver             calico-apiserver-8b9d8f8c6-ns68n                                       1/1     Running   0          13m
calico-system                calico-kube-controllers-d487d95cd-6f27z                                1/1     Running   0          13m
calico-system                calico-node-htmjl                                                      1/1     Running   0          7m33s
calico-system                calico-node-l64mb                                                      1/1     Running   0          13m
calico-system                calico-typha-66695b74c-sbmkp                                           1/1     Running   0          13m
calico-system                csi-node-driver-jl6rg                                                  2/2     Running   0          7m2s
calico-system                csi-node-driver-x2wvq                                                  2/2     Running   0          13m
default                      tigera-operator-5d4c7cd9c4-wfgkk                                       1/1     Running   0          13m
kube-system                  coredns-965bbb7bb-79kxl                                                1/1     Running   0          18m
kube-system                  coredns-965bbb7bb-8tclz                                                1/1     Running   0          18m
kube-system                  csi-oci-controller-6bffccf7d6-7qp4d                                    5/5     Running   0          13m
kube-system                  csi-oci-node-kph5t                                                     3/3     Running   0          13m
kube-system                  csi-oci-node-kwk4s                                                     3/3     Running   0          7m34s
kube-system                  etcd-ocnecapikluster-509ff004-control-plane-kt6zx                      1/1     Running   0          18m
kube-system                  kube-apiserver-ocnecapikluster-509ff004-control-plane-kt6zx            1/1     Running   0          18m
kube-system                  kube-controller-manager-ocnecapikluster-509ff004-control-plane-kt6zx   1/1     Running   0          18m
kube-system                  kube-proxy-77js6                                                       1/1     Running   0          18m
kube-system                  kube-proxy-m5lnn                                                       1/1     Running   0          7m34s
kube-system                  kube-scheduler-ocnecapikluster-509ff004-control-plane-kt6zx            1/1     Running   0          18m
kube-system                  oci-cloud-controller-manager-pcd56                                     1/1     Running   0          13m
verrazzano-install           verrazzano-platform-operator-744775575d-2xv4t                          1/1     Running   0          14m
verrazzano-install           verrazzano-platform-operator-webhook-76cf5b7cf7-8zqzc                  1/1     Running   0          14m
verrazzano-module-operator   verrazzano-module-operator-57c87f967-hmr7v                             1/1     Running   0          14m
```