### PR TITLE
specify correct repos and path for module operator and VPO

### DIFF
--- a/examples/module-operator/cluster-template-existingvcnwithaddons-disconnected-env.yaml
+++ b/examples/module-operator/cluster-template-existingvcnwithaddons-disconnected-env.yaml
@@ -100,14 +100,14 @@ spec:
     imagePullSecrets:
       - name: verrazzano-container-registry
     image:
-      repository: ${OCNE_IMAGE_REPOSITORY=container-registry.oracle.com}/${OCNE_IMAGE_PATH=olcne}
+      repository: ${OCNE_IMAGE_REPOSITORY=ghcr.io}/${VZ_IMAGE_PATH=olcne}
       tag: ${MODULE_OPERATOR_IMAGE_TAG}
   verrazzanoPlatformOperator:
     enabled: true
     imagePullSecrets:
       - name: verrazzano-container-registry
     image:
-      repository: ${OCNE_IMAGE_REPOSITORY=container-registry.oracle.com}/${OCNE_IMAGE_PATH=olcne}
+      repository: ${OCNE_IMAGE_REPOSITORY=ghcr.io}/${VZ_IMAGE_PATH=verrazzano}
       tag: ${VERRAZZANO_PLATFORM_OPERATOR_IMAGE_TAG}
     privateRegistry:
       enabled: true

--- a/examples/module-operator/cluster-template-existingvcnwithaddons-disconnected-env.yaml
+++ b/examples/module-operator/cluster-template-existingvcnwithaddons-disconnected-env.yaml
@@ -100,7 +100,7 @@ spec:
     imagePullSecrets:
       - name: verrazzano-container-registry
     image:
-      repository: ${OCNE_IMAGE_REPOSITORY=ghcr.io}/${VZ_IMAGE_PATH=olcne}
+      repository: ${OCNE_IMAGE_REPOSITORY=ghcr.io}/${VZ_IMAGE_PATH=verrazzano}
       tag: ${MODULE_OPERATOR_IMAGE_TAG}
   verrazzanoPlatformOperator:
     enabled: true


### PR DESCRIPTION
Both currently are published to ghcr.io and are in the 'verrazzano' image path.