### PR TITLE
VZ-11645.  Update example YAMLs to disable OSMS plugin

### DIFF
--- a/examples/defaultCreds/cluster-template-existingvcnwithaddonsandnoproxy-skipinstall.yaml
+++ b/examples/defaultCreds/cluster-template-existingvcnwithaddonsandnoproxy-skipinstall.yaml
@@ -122,6 +122,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
@@ -140,6 +145,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/defaultCreds/cluster-template-existingvcnwithaddonsandnoproxy.yaml
+++ b/examples/defaultCreds/cluster-template-existingvcnwithaddonsandnoproxy.yaml
@@ -119,6 +119,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
@@ -137,6 +142,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/defaultCreds/cluster-template-existingvcnwithaddonsandproxy-skipinstall.yaml
+++ b/examples/defaultCreds/cluster-template-existingvcnwithaddonsandproxy-skipinstall.yaml
@@ -126,6 +126,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
@@ -144,6 +149,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/defaultCreds/cluster-template-existingvcnwithaddonsandproxy.yaml
+++ b/examples/defaultCreds/cluster-template-existingvcnwithaddonsandproxy.yaml
@@ -124,6 +124,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
@@ -142,6 +147,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/defaultCreds/cluster-template.yaml
+++ b/examples/defaultCreds/cluster-template.yaml
@@ -99,6 +99,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
@@ -117,6 +122,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/module-operator/cluster-template-cluster-class-existingvcnwithaddons.yaml
+++ b/examples/module-operator/cluster-template-cluster-class-existingvcnwithaddons.yaml
@@ -286,6 +286,11 @@ spec:
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=4}"
         memoryInGBs: "${OCI_NODE_MACHINE_MEMORY_GBS=80}"
+      agentConfig:
+        # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -305,6 +310,11 @@ spec:
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=4}"
         memoryInGBs: "${OCI_NODE_MACHINE_MEMORY_GBS=80}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -324,6 +334,11 @@ spec:
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=4}"
         memoryInGBs: "${OCI_NODE_MACHINE_MEMORY_GBS=80}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/module-operator/cluster-template-cluster-class-existingvcnwithaddonsandproxy.yaml
+++ b/examples/module-operator/cluster-template-cluster-class-existingvcnwithaddonsandproxy.yaml
@@ -328,6 +328,11 @@ spec:
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=4}"
         memoryInGBs: "${OCI_NODE_MACHINE_MEMORY_GBS=80}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -347,6 +352,11 @@ spec:
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=4}"
         memoryInGBs: "${OCI_NODE_MACHINE_MEMORY_GBS=80}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -366,6 +376,11 @@ spec:
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=4}"
         memoryInGBs: "${OCI_NODE_MACHINE_MEMORY_GBS=80}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/module-operator/cluster-template-existingvcnwithaddons-disconnected-env.yaml
+++ b/examples/module-operator/cluster-template-existingvcnwithaddons-disconnected-env.yaml
@@ -167,6 +167,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -185,6 +190,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/module-operator/cluster-template-existingvcnwithaddons-skipinstall.yaml
+++ b/examples/module-operator/cluster-template-existingvcnwithaddons-skipinstall.yaml
@@ -155,6 +155,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -173,6 +178,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/module-operator/cluster-template-existingvcnwithaddons.yaml
+++ b/examples/module-operator/cluster-template-existingvcnwithaddons.yaml
@@ -152,6 +152,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -170,6 +175,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/module-operator/cluster-template-existingvcnwithaddonsandproxy-skipinstall.yaml
+++ b/examples/module-operator/cluster-template-existingvcnwithaddonsandproxy-skipinstall.yaml
@@ -159,6 +159,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -177,6 +182,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/module-operator/cluster-template-existingvcnwithaddonsandproxy.yaml
+++ b/examples/module-operator/cluster-template-existingvcnwithaddonsandproxy.yaml
@@ -157,6 +157,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: OCIMachineTemplate
@@ -175,6 +180,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/module-operator/cluster-template.yaml
+++ b/examples/module-operator/cluster-template.yaml
@@ -130,6 +130,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
@@ -148,6 +153,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/multi-tenancy/cluster-template-existingvcnwithaddonsandnoproxy-skipinstall.yaml
+++ b/examples/multi-tenancy/cluster-template-existingvcnwithaddonsandnoproxy-skipinstall.yaml
@@ -153,6 +153,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
@@ -171,6 +176,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/multi-tenancy/cluster-template-existingvcnwithaddonsandnoproxy.yaml
+++ b/examples/multi-tenancy/cluster-template-existingvcnwithaddonsandnoproxy.yaml
@@ -150,6 +150,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
@@ -168,6 +173,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/multi-tenancy/cluster-template-existingvcnwithaddonsandproxy-skipinstall.yaml
+++ b/examples/multi-tenancy/cluster-template-existingvcnwithaddonsandproxy-skipinstall.yaml
@@ -157,6 +157,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
@@ -175,6 +180,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/multi-tenancy/cluster-template-existingvcnwithaddonsandproxy.yaml
+++ b/examples/multi-tenancy/cluster-template-existingvcnwithaddonsandproxy.yaml
@@ -155,6 +155,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
@@ -173,6 +178,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/multi-tenancy/cluster-template.yaml
+++ b/examples/multi-tenancy/cluster-template.yaml
@@ -130,6 +130,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
@@ -148,6 +153,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/simplified/cluster-template-existingvcnwithaddonsandnoproxy-skipinstall.yaml
+++ b/examples/simplified/cluster-template-existingvcnwithaddonsandnoproxy-skipinstall.yaml
@@ -144,6 +144,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
@@ -162,6 +167,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/simplified/cluster-template-existingvcnwithaddonsandnoproxy.yaml
+++ b/examples/simplified/cluster-template-existingvcnwithaddonsandnoproxy.yaml
@@ -141,6 +141,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
@@ -159,6 +164,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/simplified/cluster-template-existingvcnwithaddonsandproxy-skipinstall.yaml
+++ b/examples/simplified/cluster-template-existingvcnwithaddonsandproxy-skipinstall.yaml
@@ -148,6 +148,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
@@ -166,6 +171,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/simplified/cluster-template-existingvcnwithaddonsandproxy.yaml
+++ b/examples/simplified/cluster-template-existingvcnwithaddonsandproxy.yaml
@@ -146,6 +146,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
@@ -164,6 +169,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate

--- a/examples/simplified/cluster-template.yaml
+++ b/examples/simplified/cluster-template.yaml
@@ -120,6 +120,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OCIMachineTemplate
@@ -138,6 +143,11 @@ spec:
       shape: ${OCI_NODE_MACHINE_TYPE=VM.Standard.E4.Flex}
       shapeConfig:
         ocpus: "${OCI_NODE_MACHINE_TYPE_OCPUS=2}"
+      # Disable the OSMS plugin as it interferes with the Yum repo setup and tool installation
+      agentConfig:
+        pluginsConfigs:
+          - desiredState: DISABLED
+            name: "OS Management Service Agent"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
 kind: OCNEConfigTemplate


### PR DESCRIPTION
Update example YAMLs to disable OSMS plugin to avoid interfering with installation of K8s utils (kubeadm, kubectl, kubelet, etc) during bootstrap.

This is fixed by adding the following snippet to all of the `OCIMachineTemplate` objects:

```
      agentConfig:
        pluginsConfigs:
        - desiredState: DISABLED
          name: "OS Management Service Agent"
```

The OSMS is preventing OL8 updates during machine bootstrap to set up the YUM repos to allow installation of OCNE and related Kuberentes utilities.  Disabling OSMS explicitly fixes the issue.

Tested fix with `cluster-template-existingvcnwithaddonsandproxy.yaml` using both an OSMS-enabled compartment and an OSMS-disabled compartment.  Both clusters came up fine.
